### PR TITLE
Mention that `map` on Result is used before implementation is shown

### DIFF
--- a/Functor and Monad in Swift/FunctorAndMonad.md
+++ b/Functor and Monad in Swift/FunctorAndMonad.md
@@ -113,7 +113,7 @@ Imagine that we wanted to read a file with string contents. We would get an `NSD
 NSData -> String -> String
 ```
 
-We can do this with a series of `map` transformations:
+We can do this with a series of `map` transformations (*we'll discuss the implementation of `map` later*):
 
 ```swift
 let data: Result<NSData> = dataWithContentsOfFile(path, NSUTF8StringEncoding)


### PR DESCRIPTION
Liked the post a lot. This was a minor thing that through me off and made me scroll back to see if I missed the implementation.

I'm sure there are other ways to fix this in case you are not happy with the parentheses. 
